### PR TITLE
[Fix] Issue with rift cli in macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Rift
 
-[![PyPI version](https://img.shields.io/badge/rift--framework-0.7.1-informational?style=flat-square&color=FFFF91)](https://pypi.org/project/rift-framework/)
+[![PyPI version](https://img.shields.io/badge/rift--framework-0.7.3-informational?style=flat-square&color=FFFF91)](https://pypi.org/project/rift-framework/)
 [![Telegram](https://img.shields.io/badge/Telegram-@rift__framework-informational?style=flat-square&color=0088cc)](https://t.me/d_builder)
 > _A magical **Python3** -> **FunC** portal_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rift-framework"
-version = "0.7.2"
+version = "0.7.3"
 description = "A magical Python3 -> FunC portal"
 authors = ["Amin Rezaei <AminRezaei0x443@gmail.com>"]
 license = "MIT"

--- a/rift/cli/util/dir_helper.py
+++ b/rift/cli/util/dir_helper.py
@@ -1,4 +1,5 @@
 from os import makedirs, path, umask
+import traceback
 
 
 class _DirNode:
@@ -49,7 +50,9 @@ class DirectoryStructure(_DirNode):
             try:
                 _prev_umask = umask(0)
                 makedirs(p, exists_ok, mode=0o777)
-            except Exception:
+            except Exception as e:
+                print(e)
+                traceback.print_exc()
                 return False
             finally:
                 umask(_prev_umask)

--- a/rift/cli/util/dir_helper.py
+++ b/rift/cli/util/dir_helper.py
@@ -49,7 +49,7 @@ class DirectoryStructure(_DirNode):
             p = leaf.as_dir()
             try:
                 _prev_umask = umask(0)
-                makedirs(p, exists_ok, 0o777)
+                makedirs(p, 0o777, exists_ok)
             except Exception as e:
                 print(e)
                 traceback.print_exc()

--- a/rift/cli/util/dir_helper.py
+++ b/rift/cli/util/dir_helper.py
@@ -48,12 +48,7 @@ class DirectoryStructure(_DirNode):
         for leaf in self.leaves():
             p = leaf.as_dir()
             try:
-                _prev_umask = umask(0)
                 makedirs(p, 0o777, exists_ok)
-            except Exception as e:
-                print(e)
-                traceback.print_exc()
+            except Exception:
                 return False
-            finally:
-                umask(_prev_umask)
         return True

--- a/rift/cli/util/dir_helper.py
+++ b/rift/cli/util/dir_helper.py
@@ -1,4 +1,4 @@
-from os import makedirs, path
+from os import makedirs, path, umask
 
 
 class _DirNode:
@@ -47,7 +47,10 @@ class DirectoryStructure(_DirNode):
         for leaf in self.leaves():
             p = leaf.as_dir()
             try:
-                makedirs(p, exists_ok)
+                _prev_umask = umask(0)
+                makedirs(p, exists_ok, mode=0o777)
             except Exception:
                 return False
+            finally:
+                umask(_prev_umask)
         return True

--- a/rift/cli/util/dir_helper.py
+++ b/rift/cli/util/dir_helper.py
@@ -49,7 +49,7 @@ class DirectoryStructure(_DirNode):
             p = leaf.as_dir()
             try:
                 _prev_umask = umask(0)
-                makedirs(p, exists_ok, mode=0o777)
+                makedirs(p, exists_ok, 0o777)
             except Exception as e:
                 print(e)
                 traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="rift-framework",
-    version="0.7.2",
+    version="0.7.3",
     description="A magical Python3 -> FunC portal",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
Fixed call to `os.makedirs` so `rift init` is working fine in macOS too. 

This was due to the interpretation of a `bool` arg as `0o000` mode which resulted in directories with no permission to read or write files in them.

This fix resolves #7 , #8 , #10.